### PR TITLE
Use a interface for StreamWatcher

### DIFF
--- a/quadlek/twitch.go
+++ b/quadlek/twitch.go
@@ -115,10 +115,6 @@ func twitchCommand(ctx context.Context, cmdChannel <-chan *quadlek.CommandMsg) {
 }
 
 func watch(bot *quadlek.Bot, follow *TwitchFollow) {
-	if follow.streamWatcher == nil {
-		follow.s
-	}
-
 	for {
 		select {
 		case <-follow.ctx.Done():

--- a/quadlek/twitch.go
+++ b/quadlek/twitch.go
@@ -27,8 +27,8 @@ type TwitchFollow struct {
 	user   *libtwitch.User
 	stream *libtwitch.Stream
 
-	streamWatcher *libtwitch.StreamWatcher
-	followWatcher *libtwitch.StreamWatcher
+	streamWatcher libtwitch.Watcher
+	followWatcher libtwitch.Watcher
 }
 
 var twitchClient *libtwitch.TwitchClient
@@ -115,6 +115,9 @@ func twitchCommand(ctx context.Context, cmdChannel <-chan *quadlek.CommandMsg) {
 }
 
 func watch(bot *quadlek.Bot, follow *TwitchFollow) {
+	if follow.streamWatcher == nil {
+		follow.s
+	}
 
 	for {
 		select {
@@ -184,6 +187,8 @@ func load(ctx context.Context, follows []*TwitchFollow) func(bot *quadlek.Bot, s
 					continue
 				}
 				follow.streamWatcher = sw
+			} else {
+				follow.streamWatcher = &libtwitch.NilStreamWatcher{}
 			}
 
 			// (optionally) Start following follow events
@@ -195,6 +200,8 @@ func load(ctx context.Context, follows []*TwitchFollow) func(bot *quadlek.Bot, s
 					continue
 				}
 				follow.followWatcher = sw
+			} else {
+				follow.followWatcher = &libtwitch.NilStreamWatcher{}
 			}
 
 			go watch(bot, follow)

--- a/webhooks.go
+++ b/webhooks.go
@@ -175,6 +175,12 @@ func (c *TwitchClient) WebhookHandler() http.HandlerFunc {
 	}
 }
 
+type Watcher interface {
+	Streams() <-chan *Stream
+	Follows() <-chan *Follow
+	Close()
+}
+
 type StreamWatcher struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -331,4 +337,17 @@ func (c *TwitchClient) WatchStream(userID string) (*StreamWatcher, error) {
 
 func (c *TwitchClient) WatchFollows(userID string) (*StreamWatcher, error) {
 	return c.addStreamWatcher("follows", userID)
+}
+
+type NilStreamWatcher struct {}
+
+func (NilStreamWatcher) Streams() <-chan *Stream {
+	return make(<-chan *Stream)
+}
+
+func (NilStreamWatcher) Follows() <-chan *Follow {
+	return make(<-chan *Follow)
+}
+
+func (NilStreamWatcher) Close() {
 }


### PR DESCRIPTION
If we opt out of following either streams or follows, we need to be sure that we don't run into a NPE when reading from the channel it provides. To solve this we use a nil stream watcher that returns channels that can't be written to. 

To trigger this, leave out `WatchFollows` in the config for the quadlek plugin.